### PR TITLE
BugFix: change out wchar_t type which is too narrow on Windows

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -125,12 +125,12 @@ static const struct {p}range {p}widened_table[] = {{
 template<typename Collection>
 bool {p}in_table(const Collection &arr, int32_t c) {{
     auto where = std::lower_bound(std::begin(arr), std::end(arr), c,
-        []({p}range p, wchar_t c) {{ return p.hi < c; }});
+        []({p}range p, int32_t c) {{ return p.hi < c; }});
     return where != std::end(arr) && where->lo <= c;
 }}
 
 /* Return the width of character c, or a special negative value. */
-int {p}wcwidth(wchar_t c) {{
+int {p}wcwidth(int32_t c) {{
     if ({p}in_table({p}ascii_table, c))
         return 1;
     if ({p}in_table({p}private_table, c))

--- a/widechar_width.h
+++ b/widechar_width.h
@@ -1,5 +1,5 @@
 /**
- * widechar_width.h, generated on 2019-05-13.
+ * widechar_width.h, generated on 2019-10-30.
  * See https://github.com/ridiculousfish/widecharwidth/
  *
  * SHA1 file hashes:
@@ -508,12 +508,12 @@ static const struct widechar_range widechar_widened_table[] = {
 template<typename Collection>
 bool widechar_in_table(const Collection &arr, int32_t c) {
     auto where = std::lower_bound(std::begin(arr), std::end(arr), c,
-        [](widechar_range p, wchar_t c) { return p.hi < c; });
+        [](widechar_range p, int32_t c) { return p.hi < c; });
     return where != std::end(arr) && where->lo <= c;
 }
 
 /* Return the width of character c, or a special negative value. */
-int widechar_wcwidth(wchar_t c) {
+int widechar_wcwidth(int32_t c) {
     if (widechar_in_table(widechar_ascii_table, c))
         return 1;
     if (widechar_in_table(widechar_private_table, c))


### PR DESCRIPTION
Specifically it is only 16 bits and as we are using it to pass a Unicode codepoint it needs to have at least 21! This does mean however that any surrogate pairs i.e. UTF-16 encoded characters that are not on the BMP and are conveyed by TWO 16 bit values, MUST be converted to a UTF-32 value before being fed to `(int) widechar_wcwidth(int32_t c)`!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>