### PR TITLE
Use width 0 for Hangul Jamo vowels and trailing consonants

### DIFF
--- a/test.cpp
+++ b/test.cpp
@@ -30,6 +30,9 @@ static bool exceptional(int c) {
         wcwidth9_intable(wcwidth9_not_assigned, WCWIDTH9_ARRAY_SIZE(wcwidth9_not_assigned), c)) {
         return true;
     }
+    if ((c >= 0x1160 && c <= 0x11FF) || (c >= 0xD7B0 && c <= 0xD7FF)) {
+        return true;
+    }
     switch (c) {
             // Format (Cf) characters which wcwidth9 reports as width 1 but should be
             // -1

--- a/widechar_width.h
+++ b/widechar_width.h
@@ -1,5 +1,5 @@
 /**
- * widechar_width.h, generated on 2021-11-24.
+ * widechar_width.h, generated on 2022-01-01.
  * See https://github.com/ridiculousfish/widecharwidth/
  *
  * SHA1 file hashes:
@@ -376,6 +376,12 @@ static const struct widechar_range widechar_combining_table[] = {
     {0x1E8D0, 0x1E8D6},
     {0x1E944, 0x1E94A},
     {0xE0100, 0xE01EF}
+};
+
+/* Width 0 combining letters. */
+static const struct widechar_range widechar_combiningletters_table[] = {
+    {0x01160, 0x011FF},
+    {0x0D7B0, 0x0D7FF}
 };
 
 /* Width 2 characters. */
@@ -1462,6 +1468,8 @@ int widechar_wcwidth(uint32_t c) {
     if (widechar_in_table(widechar_nonchar_table, c))
         return widechar_non_character;
     if (widechar_in_table(widechar_combining_table, c))
+        return widechar_combining;
+    if (widechar_in_table(widechar_combiningletters_table, c))
         return widechar_combining;
     if (widechar_in_table(widechar_doublewide_table, c))
         return 2;

--- a/widechar_width.js
+++ b/widechar_width.js
@@ -1,5 +1,5 @@
 /*
- * widechar_width.js, generated on 2021-11-24.
+ * widechar_width.js, generated on 2022-01-01.
  * See https://github.com/ridiculousfish/widecharwidth/
  *
  * SHA1 file hashes:
@@ -358,6 +358,12 @@ const widechar_combining_table = [
     [0x1E8D0, 0x1E8D6],
     [0x1E944, 0x1E94A],
     [0xE0100, 0xE01EF]
+];
+
+/* Width 0 combining letters. */
+const widechar_combiningletters_table = [
+    [0x01160, 0x011FF],
+    [0x0D7B0, 0x0D7FF]
 ];
 
 /* Width.2 characters. */
@@ -1459,6 +1465,8 @@ function widechar_wcwidth(c) {
     if (widechar_in_table(widechar_nonchar_table, c))
         return widechar_non_character;
     if (widechar_in_table(widechar_combining_table, c))
+        return widechar_combining;
+    if (widechar_in_table(widechar_combiningletters_table, c))
         return widechar_combining;
     if (widechar_in_table(widechar_doublewide_table, c))
         return 2;

--- a/widechar_width.rs
+++ b/widechar_width.rs
@@ -1,5 +1,5 @@
 /**
- * widechar_width.rs, generated on 2021-11-24.
+ * widechar_width.rs, generated on 2022-01-01.
  * See https://github.com/ridiculousfish/widecharwidth/
  *
  * SHA1 file hashes:
@@ -373,6 +373,12 @@ const COMBINING_TABLE: &'static [R] = &[
     (0x1E8D0, 0x1E8D6),
     (0x1E944, 0x1E94A),
     (0xE0100, 0xE01EF)
+];
+
+/// Width 0 combining letters.
+const COMBININGLETTERS_TABLE: &'static [R] = &[
+    (0x01160, 0x011FF),
+    (0x0D7B0, 0x0D7FF)
 ];
 
 /// Width 2 characters.
@@ -1466,6 +1472,9 @@ impl WcWidth {
             return Self::NonCharacter;
         }
         if in_table(&COMBINING_TABLE, c) {
+            return Self::Combining;
+        }
+        if in_table(&COMBININGLETTERS_TABLE, c) {
             return Self::Combining;
         }
         if in_table(&DOUBLEWIDE_TABLE, c) {


### PR DESCRIPTION
(see commit message)

Closes #16
