### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,18 @@
+name: tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Test
+      run: make

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ widechar_width.h widechar_width.js widechar_width.rs: generate.py
 
 wcwidth9.h:
 	@echo "Tests require original wcwidth9.h from https://github.com/joshuarubin/wcwidth9"
-	@false
+	wget https://raw.githubusercontent.com/joshuarubin/wcwidth9/master/wcwidth9.h
 
 rust: widechar_width.rs
 	rustc widechar_width.rs --crate-type lib --test

--- a/generate.py
+++ b/generate.py
@@ -330,7 +330,7 @@ mod test {{
         assert_eq!(WcWidth::from_char('\x1f'), WcWidth::NonPrint);
         assert_eq!(WcWidth::from_char('\u{{e001}}'), WcWidth::PrivateUse);
         assert_eq!(WcWidth::from_char('\u{{2716}}'), WcWidth::One);
-        assert_eq!(WcWidth::from_char('\u{{270a}}'), WcWidth::Two);
+        assert_eq!(WcWidth::from_char('\u{{270a}}'), WcWidth::WidenedIn9);
         assert_eq!(WcWidth::from_char('\u{{3fffd}}'), WcWidth::Two);
     }}
 }}

--- a/widechar_width.rs
+++ b/widechar_width.rs
@@ -1527,7 +1527,7 @@ mod test {
         assert_eq!(WcWidth::from_char('\x1f'), WcWidth::NonPrint);
         assert_eq!(WcWidth::from_char('\u{e001}'), WcWidth::PrivateUse);
         assert_eq!(WcWidth::from_char('\u{2716}'), WcWidth::One);
-        assert_eq!(WcWidth::from_char('\u{270a}'), WcWidth::Two);
+        assert_eq!(WcWidth::from_char('\u{270a}'), WcWidth::WidenedIn9);
         assert_eq!(WcWidth::from_char('\u{3fffd}'), WcWidth::Two);
     }
 }


### PR DESCRIPTION
This PR stacks on top of https://github.com/ridiculousfish/widecharwidth/pull/18 but adds a basic GH Actions CI workflow to run the tests for both PRs and pushes to the main line