### PR TITLE
Make build reproducible

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -347,6 +347,7 @@ def make_fields(
     fields = {
         "p": CPP_PREFIX,
         "filename": filename,
+        "unicode_version": VERSION,
         "generate_hash": generate_hash,
         "template_hash": template_hash,
         "unicode_hash": datas.unicode_hash,

--- a/generate.py
+++ b/generate.py
@@ -297,7 +297,12 @@ def make_codepoints(datas: UnicodeDatas):
 
 
 def make_fields(
-    datas: UnicodeDatas, cps: list[CodePoint], settings: LangSettings, filename
+    datas: UnicodeDatas,
+    cps: list[CodePoint],
+    settings: LangSettings,
+    template_hash: str,
+    generate_hash: str,
+    filename,
 ):
     """Return a dictionary of fields, ready to be plugged into a template string."""
     log("Thinking...")
@@ -341,7 +346,8 @@ def make_fields(
     fields = {
         "p": CPP_PREFIX,
         "filename": filename,
-        "today": str(datetime.date.today()),
+        "generate_hash": generate_hash,
+        "template_hash": template_hash,
         "unicode_hash": datas.unicode_hash,
         "eaw_hash": datas.eaw_hash,
         "emoji_hash": datas.emoji_hash,
@@ -360,6 +366,9 @@ def make_fields(
 
 
 if __name__ == "__main__":
+    with open(__file__, "rb") as oof:
+        data = oof.read()
+    generate_hash = hashlib.sha1(data).hexdigest()
     datas = read_datas()
     cps = make_codepoints(datas)
     langs = {
@@ -370,8 +379,11 @@ if __name__ == "__main__":
     for suffix, settings in langs.items():
         with open("templates/template" + suffix) as templatefile:
             template = templatefile.read()
+            template_hash = hashlib.sha1(template.encode("utf-8")).hexdigest()
             output = "widechar_width" + suffix
-            fields = make_fields(datas, cps, LangSettings(settings), output)
+            fields = make_fields(
+                datas, cps, LangSettings(settings), template_hash, generate_hash, output
+            )
             with open(output, "w") as fd:
                 fd.write(template.strip().format(**fields))
                 fd.write("\n")

--- a/generate.py
+++ b/generate.py
@@ -367,10 +367,19 @@ def make_fields(
     return fields
 
 
+def gitobjecthash(data):
+    """Generate the git object hash of a bit of data
+    like `git hash-object`
+    """
+    h = hashlib.sha1()
+    h.update(b"blob %u\0" % len(data))
+    h.update(data)
+    return h.hexdigest()
+
 if __name__ == "__main__":
     with open(__file__, "rb") as oof:
         data = oof.read()
-    generate_hash = hashlib.sha1(data).hexdigest()
+    generate_hash = gitobjecthash(data)
     datas = read_datas()
     cps = make_codepoints(datas)
     langs = {
@@ -381,7 +390,7 @@ if __name__ == "__main__":
     for suffix, settings in langs.items():
         with open("templates/template" + suffix) as templatefile:
             template = templatefile.read()
-            template_hash = hashlib.sha1(template.encode("utf-8")).hexdigest()
+            template_hash = gitobjecthash(template.encode("utf-8"))
             output = "widechar_width" + suffix
             fields = make_fields(
                 datas, cps, LangSettings(settings), template_hash, generate_hash, output

--- a/generate.py
+++ b/generate.py
@@ -236,7 +236,7 @@ def set_emoji_widths(emoji_data_lines, cps):
     for line in emoji_data_lines:
         for (cp, version, prop) in parse_emoji_line(line):
             # The Regional Indicators are special
-            if cp in range(0x1f1e6, 0x1f200):
+            if cp in range(0x1F1E6, 0x1F200):
                 continue
 
             # We only care about emoji *presentation*.
@@ -247,6 +247,7 @@ def set_emoji_widths(emoji_data_lines, cps):
                 # The version we get here is the *Emoji* version.
                 # Before Unicode 11 this was different, Unicode 9 shipped with Emoji 3.0.
                 cps[cp].width = 2 if version >= 3.0 else WIDTH_WIDENED_IN_9
+
 
 def set_hardcoded_ranges(cps):
     """Mark private use and surrogate codepoints"""

--- a/templates/template.h
+++ b/templates/template.h
@@ -1,5 +1,5 @@
 /**
- * {filename}
+ * {filename} for Unicode {unicode_version}
  * See https://github.com/ridiculousfish/widecharwidth/
  *
  * SHA1 file hashes:

--- a/templates/template.h
+++ b/templates/template.h
@@ -1,8 +1,10 @@
 /**
- * {filename}, generated on {today}.
+ * {filename}
  * See https://github.com/ridiculousfish/widecharwidth/
  *
  * SHA1 file hashes:
+ *  generate.py:         {generate_hash}
+ *  template.h:          {template_hash}
  *  UnicodeData.txt:     {unicode_hash}
  *  EastAsianWidth.txt:  {eaw_hash}
  *  emoji-data.txt:      {emoji_hash}

--- a/templates/template.h
+++ b/templates/template.h
@@ -3,8 +3,16 @@
  * See https://github.com/ridiculousfish/widecharwidth/
  *
  * SHA1 file hashes:
+ *  (
+ *  the hashes for generate.py and the template are git object hashes,
+ *  use `git log --all --find-object=<hash>` in the widecharwidth repository
+ *  to see which commit they correspond to,
+ *  or run `git hash-object` on the file to compare.
+ *  The other hashes are simple `sha1sum` style hashes.
+ *  )
+ *
  *  generate.py:         {generate_hash}
- *  template.h:          {template_hash}
+ *  template.js:         {template_hash}
  *  UnicodeData.txt:     {unicode_hash}
  *  EastAsianWidth.txt:  {eaw_hash}
  *  emoji-data.txt:      {emoji_hash}

--- a/templates/template.js
+++ b/templates/template.js
@@ -1,8 +1,10 @@
 /*
- * {filename}, generated on {today}.
+ * {filename}
  * See https://github.com/ridiculousfish/widecharwidth/
  *
  * SHA1 file hashes:
+ *  generate.py:         {generate_hash}
+ *  template.js:         {template_hash}
  *  UnicodeData.txt:     {unicode_hash}
  *  EastAsianWidth.txt:  {eaw_hash}
  *  emoji-data.txt:      {emoji_hash}

--- a/templates/template.js
+++ b/templates/template.js
@@ -1,5 +1,5 @@
 /*
- * {filename}
+ * {filename} for Unicode {unicode_version}
  * See https://github.com/ridiculousfish/widecharwidth/
  *
  * SHA1 file hashes:

--- a/templates/template.js
+++ b/templates/template.js
@@ -3,6 +3,14 @@
  * See https://github.com/ridiculousfish/widecharwidth/
  *
  * SHA1 file hashes:
+ *  (
+ *  the hashes for generate.py and the template are git object hashes,
+ *  use `git log --all --find-object=<hash>` in the widecharwidth repository
+ *  to see which commit they correspond to,
+ *  or run `git hash-object` on the file to compare.
+ *  The other hashes are simple `sha1sum` style hashes.
+ *  )
+ *
  *  generate.py:         {generate_hash}
  *  template.js:         {template_hash}
  *  UnicodeData.txt:     {unicode_hash}

--- a/templates/template.rs
+++ b/templates/template.rs
@@ -1,8 +1,10 @@
 /**
- * {filename}, generated on {today}.
+ * {filename}
  * See https://github.com/ridiculousfish/widecharwidth/
  *
  * SHA1 file hashes:
+ *  generate.py:         {generate_hash}
+ *  template.rs:         {template_hash}
  *  UnicodeData.txt:     {unicode_hash}
  *  EastAsianWidth.txt:  {eaw_hash}
  *  emoji-data.txt:      {emoji_hash}

--- a/templates/template.rs
+++ b/templates/template.rs
@@ -1,5 +1,5 @@
 /**
- * {filename}
+ * {filename} for Unicode {unicode_version}
  * See https://github.com/ridiculousfish/widecharwidth/
  *
  * SHA1 file hashes:

--- a/templates/template.rs
+++ b/templates/template.rs
@@ -3,8 +3,16 @@
  * See https://github.com/ridiculousfish/widecharwidth/
  *
  * SHA1 file hashes:
+ *  (
+ *  the hashes for generate.py and the template are git object hashes,
+ *  use `git log --all --find-object=<hash>` in the widecharwidth repository
+ *  to see which commit they correspond to,
+ *  or run `git hash-object` on the file to compare.
+ *  The other hashes are simple `sha1sum` style hashes.
+ *  )
+ *
  *  generate.py:         {generate_hash}
- *  template.rs:         {template_hash}
+ *  template.js:         {template_hash}
  *  UnicodeData.txt:     {unicode_hash}
  *  EastAsianWidth.txt:  {eaw_hash}
  *  emoji-data.txt:      {emoji_hash}

--- a/widechar_width.h
+++ b/widechar_width.h
@@ -3,8 +3,16 @@
  * See https://github.com/ridiculousfish/widecharwidth/
  *
  * SHA1 file hashes:
- *  generate.py:         2a3bcf61a23572f3fa35c93c192e9e1be7eeb559
- *  template.h:          a141cafe7ae69f7a30241c72596bd13e3343c31b
+ *  (
+ *  the hashes for generate.py and the template are git object hashes,
+ *  use `git log --all --find-object=<hash>` in the widecharwidth repository
+ *  to see which commit they correspond to,
+ *  or run `git hash-object` on the file to compare.
+ *  The other hashes are simple `sha1sum` style hashes.
+ *  )
+ *
+ *  generate.py:         90303b8633e230ffeddbed07c294d0c2c0b317d8
+ *  template.js:         1249763c5b7c1e308aeb4ca64f1e15bce1fab9b3
  *  UnicodeData.txt:     8a5c26bfb27df8cfab23cf2c34c62d8d3075ae4d
  *  EastAsianWidth.txt:  8ec36ccac3852bf0c2f02e37c6151551cd14db72
  *  emoji-data.txt:      3f0ec08c001c4bc6df0b07d01068fc73808bfb4c

--- a/widechar_width.h
+++ b/widechar_width.h
@@ -1,8 +1,10 @@
 /**
- * widechar_width.h, generated on 2022-02-12.
+ * widechar_width.h
  * See https://github.com/ridiculousfish/widecharwidth/
  *
  * SHA1 file hashes:
+ *  generate.py:         1e1b86363d41ac47b4812344fe6313dd77de8279
+ *  template.h:          a4eedf439d08cfb0f069c08e0374fbbabe9c87c5
  *  UnicodeData.txt:     8a5c26bfb27df8cfab23cf2c34c62d8d3075ae4d
  *  EastAsianWidth.txt:  8ec36ccac3852bf0c2f02e37c6151551cd14db72
  *  emoji-data.txt:      3f0ec08c001c4bc6df0b07d01068fc73808bfb4c

--- a/widechar_width.h
+++ b/widechar_width.h
@@ -1,10 +1,10 @@
 /**
- * widechar_width.h
+ * widechar_width.h for Unicode 14.0.0
  * See https://github.com/ridiculousfish/widecharwidth/
  *
  * SHA1 file hashes:
- *  generate.py:         1e1b86363d41ac47b4812344fe6313dd77de8279
- *  template.h:          a4eedf439d08cfb0f069c08e0374fbbabe9c87c5
+ *  generate.py:         2a3bcf61a23572f3fa35c93c192e9e1be7eeb559
+ *  template.h:          a141cafe7ae69f7a30241c72596bd13e3343c31b
  *  UnicodeData.txt:     8a5c26bfb27df8cfab23cf2c34c62d8d3075ae4d
  *  EastAsianWidth.txt:  8ec36ccac3852bf0c2f02e37c6151551cd14db72
  *  emoji-data.txt:      3f0ec08c001c4bc6df0b07d01068fc73808bfb4c

--- a/widechar_width.js
+++ b/widechar_width.js
@@ -1,8 +1,10 @@
 /*
- * widechar_width.js, generated on 2022-02-12.
+ * widechar_width.js
  * See https://github.com/ridiculousfish/widecharwidth/
  *
  * SHA1 file hashes:
+ *  generate.py:         1e1b86363d41ac47b4812344fe6313dd77de8279
+ *  template.js:         93220a99ef778f00e273bf8aaf16f454aa7a0b41
  *  UnicodeData.txt:     8a5c26bfb27df8cfab23cf2c34c62d8d3075ae4d
  *  EastAsianWidth.txt:  8ec36ccac3852bf0c2f02e37c6151551cd14db72
  *  emoji-data.txt:      3f0ec08c001c4bc6df0b07d01068fc73808bfb4c

--- a/widechar_width.js
+++ b/widechar_width.js
@@ -1,10 +1,10 @@
 /*
- * widechar_width.js
+ * widechar_width.js for Unicode 14.0.0
  * See https://github.com/ridiculousfish/widecharwidth/
  *
  * SHA1 file hashes:
- *  generate.py:         1e1b86363d41ac47b4812344fe6313dd77de8279
- *  template.js:         93220a99ef778f00e273bf8aaf16f454aa7a0b41
+ *  generate.py:         2a3bcf61a23572f3fa35c93c192e9e1be7eeb559
+ *  template.js:         db3d7e768040ade081aff9aa7298cc056031a637
  *  UnicodeData.txt:     8a5c26bfb27df8cfab23cf2c34c62d8d3075ae4d
  *  EastAsianWidth.txt:  8ec36ccac3852bf0c2f02e37c6151551cd14db72
  *  emoji-data.txt:      3f0ec08c001c4bc6df0b07d01068fc73808bfb4c

--- a/widechar_width.js
+++ b/widechar_width.js
@@ -3,8 +3,16 @@
  * See https://github.com/ridiculousfish/widecharwidth/
  *
  * SHA1 file hashes:
- *  generate.py:         2a3bcf61a23572f3fa35c93c192e9e1be7eeb559
- *  template.js:         db3d7e768040ade081aff9aa7298cc056031a637
+ *  (
+ *  the hashes for generate.py and the template are git object hashes,
+ *  use `git log --all --find-object=<hash>` in the widecharwidth repository
+ *  to see which commit they correspond to,
+ *  or run `git hash-object` on the file to compare.
+ *  The other hashes are simple `sha1sum` style hashes.
+ *  )
+ *
+ *  generate.py:         90303b8633e230ffeddbed07c294d0c2c0b317d8
+ *  template.js:         81d7e9c034b63326d422dfe3fdf07e2b0cbec801
  *  UnicodeData.txt:     8a5c26bfb27df8cfab23cf2c34c62d8d3075ae4d
  *  EastAsianWidth.txt:  8ec36ccac3852bf0c2f02e37c6151551cd14db72
  *  emoji-data.txt:      3f0ec08c001c4bc6df0b07d01068fc73808bfb4c

--- a/widechar_width.rs
+++ b/widechar_width.rs
@@ -1,8 +1,10 @@
 /**
- * widechar_width.rs, generated on 2022-02-12.
+ * widechar_width.rs
  * See https://github.com/ridiculousfish/widecharwidth/
  *
  * SHA1 file hashes:
+ *  generate.py:         1e1b86363d41ac47b4812344fe6313dd77de8279
+ *  template.rs:         d8e4f9bb935e738f193b9cb2c33df4d65d4c19b7
  *  UnicodeData.txt:     8a5c26bfb27df8cfab23cf2c34c62d8d3075ae4d
  *  EastAsianWidth.txt:  8ec36ccac3852bf0c2f02e37c6151551cd14db72
  *  emoji-data.txt:      3f0ec08c001c4bc6df0b07d01068fc73808bfb4c

--- a/widechar_width.rs
+++ b/widechar_width.rs
@@ -1,10 +1,10 @@
 /**
- * widechar_width.rs
+ * widechar_width.rs for Unicode 14.0.0
  * See https://github.com/ridiculousfish/widecharwidth/
  *
  * SHA1 file hashes:
- *  generate.py:         1e1b86363d41ac47b4812344fe6313dd77de8279
- *  template.rs:         d8e4f9bb935e738f193b9cb2c33df4d65d4c19b7
+ *  generate.py:         2a3bcf61a23572f3fa35c93c192e9e1be7eeb559
+ *  template.rs:         675961b58c767f6c25eaa66f2489c7d46a6bd129
  *  UnicodeData.txt:     8a5c26bfb27df8cfab23cf2c34c62d8d3075ae4d
  *  EastAsianWidth.txt:  8ec36ccac3852bf0c2f02e37c6151551cd14db72
  *  emoji-data.txt:      3f0ec08c001c4bc6df0b07d01068fc73808bfb4c

--- a/widechar_width.rs
+++ b/widechar_width.rs
@@ -3,8 +3,16 @@
  * See https://github.com/ridiculousfish/widecharwidth/
  *
  * SHA1 file hashes:
- *  generate.py:         2a3bcf61a23572f3fa35c93c192e9e1be7eeb559
- *  template.rs:         675961b58c767f6c25eaa66f2489c7d46a6bd129
+ *  (
+ *  the hashes for generate.py and the template are git object hashes,
+ *  use `git log --all --find-object=<hash>` in the widecharwidth repository
+ *  to see which commit they correspond to,
+ *  or run `git hash-object` on the file to compare.
+ *  The other hashes are simple `sha1sum` style hashes.
+ *  )
+ *
+ *  generate.py:         90303b8633e230ffeddbed07c294d0c2c0b317d8
+ *  template.js:         155382626d7f69119cc981aeec4bb115b516a7a0
  *  UnicodeData.txt:     8a5c26bfb27df8cfab23cf2c34c62d8d3075ae4d
  *  EastAsianWidth.txt:  8ec36ccac3852bf0c2f02e37c6151551cd14db72
  *  emoji-data.txt:      3f0ec08c001c4bc6df0b07d01068fc73808bfb4c


### PR DESCRIPTION
This removes the date and adds the hashes for generate.py and the templates instead.

The idea here is that, given the same inputs, you should get the same outputs. The date is also not *important*, it's mostly a proxy for how up-to-date it is. So we include the unicode version directly.

It would be cool to have a monotonically increasing generate/template version, but I have no idea how.

PR based on #20.