### PR TITLE
optimize rust code

### DIFF
--- a/templates/template.rs
+++ b/templates/template.rs
@@ -21,6 +21,7 @@
 type R = (u32, u32);
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u8)]
 pub enum WcWidth {{
   /// The character is single-width
   One,
@@ -93,11 +94,14 @@ const WIDENED_TABLE: &'static [R] = &[
 ];
 
 fn in_table(arr: &[R], c: u32) -> bool {{
-    arr.binary_search_by(|(start, end)| if c >= *start && c <= *end {{
-        std::cmp::Ordering::Equal
-    }} else {{
-        start.cmp(&c)
-    }}).is_ok()
+    arr.binary_search_by(|(start, end)| {{
+        if c >= *start && c <= *end {{
+            std::cmp::Ordering::Equal
+        }} else {{
+            start.cmp(&c)
+        }}
+    }})
+    .is_ok()
 }}
 
 impl WcWidth {{
@@ -138,6 +142,7 @@ impl WcWidth {{
     }}
 
     /// Returns width for applications that are using unicode 8 or earlier
+    #[inline]
     pub fn width_unicode_8_or_earlier(self) -> u8 {{
         match self {{
             Self::One => 1,
@@ -149,11 +154,96 @@ impl WcWidth {{
     }}
 
     /// Returns width for applications that are using unicode 9 or later
+    #[inline]
     pub fn width_unicode_9_or_later(self) -> u8 {{
         if self == Self::WidenedIn9 {{
             return 2;
         }}
         self.width_unicode_8_or_earlier()
+    }}
+}}
+
+/// An alternative interface that precomputes the values for the first 64k
+/// codepoints and maintains a table that is 64kb in size.
+/// Lookups are then a simple O(1) index operation that takes ~1.5ns
+/// constant time for codepoints in that range, falling back to
+/// the regular WcWidth::from_char for codepoints outside that range
+/// (which takes 20-75ns depending on the codepoint and which table
+/// it is resolved to)
+pub struct WcLookupTable {{
+    pub table: [WcWidth; 65536],
+}}
+
+impl WcLookupTable {{
+    #[allow(unused)]
+    pub fn new() -> Self {{
+        let mut table = [WcWidth::One; 65536];
+        // Populate the table with data from the other tables in
+        // the reverse order to that used to lookup in
+        // WcWidth::from_char so that the precedence is the
+        // same in the event that there are any overlaps.
+        for &(start, end) in WIDENED_TABLE {{
+            for i in start..=end.min(0xffff) {{
+                table[i as usize] = WcWidth::WidenedIn9;
+            }}
+        }}
+        for &(start, end) in UNASSIGNED_TABLE {{
+            for i in start..=end.min(0xffff) {{
+                table[i as usize] = WcWidth::Unassigned;
+            }}
+        }}
+        for &(start, end) in AMBIGUOUS_TABLE {{
+            for i in start..=end.min(0xffff) {{
+                table[i as usize] = WcWidth::Ambiguous;
+            }}
+        }}
+        for &(start, end) in DOUBLEWIDE_TABLE {{
+            for i in start..=end.min(0xffff) {{
+                table[i as usize] = WcWidth::Two;
+            }}
+        }}
+        for &(start, end) in COMBININGLETTERS_TABLE {{
+            for i in start..=end.min(0xffff) {{
+                table[i as usize] = WcWidth::Combining;
+            }}
+        }}
+        for &(start, end) in COMBINING_TABLE {{
+            for i in start..=end.min(0xffff) {{
+                table[i as usize] = WcWidth::Combining;
+            }}
+        }}
+        for &(start, end) in NONCHAR_TABLE {{
+            for i in start..=end.min(0xffff) {{
+                table[i as usize] = WcWidth::NonCharacter;
+            }}
+        }}
+        for &(start, end) in NONPRINT_TABLE {{
+            for i in start..=end.min(0xffff) {{
+                table[i as usize] = WcWidth::NonPrint;
+            }}
+        }}
+        for &(start, end) in PRIVATE_TABLE {{
+            for i in start..=end.min(0xffff) {{
+                table[i as usize] = WcWidth::PrivateUse;
+            }}
+        }}
+        /* Implicit, as we initialized to One
+        for &(start, end) in ASCII_TABLE {{
+            for i in start..=end.min(0xffff) {{
+                table[i as usize] = WcWidth::One;
+            }}
+        }}
+        */
+        Self {{ table }}
+    }}
+
+    /// Classify a char as a WcWidth
+    pub fn classify(&self, c: char) -> WcWidth {{
+        let c32 = c as u32;
+        if c32 <= 0xffff {{
+            return self.table[c32 as usize];
+        }}
+        WcWidth::from_char(c)
     }}
 }}
 


### PR DESCRIPTION
This commit holds some optimizations that I made for wezterm at the end of April; the meat of this is from:

https://github.com/wez/wezterm/commit/308bbc90381af11abc1a1cf9a4d4f63c341b8dfc

The commit message is included here for sake of easier understanding in this repo:

termwiz: micro-optimize grapheme_column_width

While profiling `time cat bigfile` I noted that a big chunk of the time is spent computing widths, so I wanted to dig into a bit.

After playing around with a few options, I settled on the approach in this commit.

The key observations:

* WcWidth::from_char performs a series of binary searches. The fast path was for ASCII, but anything outside that range suffered in terms of latency.
* Binary search does a lot more work than a simple table lookup, so it is desirable to use a lookup, and moreso to combine the different tables into a single table so that classification is an O(1) super fast lookup in the most common cases.

Here's some benchmarking results comparing the prior implementation (grapheme_column_width) against this new pre-computed table implementation (grapheme_column_width_tbl).

The ASCII case is more than 5x faster than before at a reasonably snappy ~3.5ns, with the more complex cases being closer to a constant ~20ns down from 120ns in some cases.

There are changes here to widechar_width.rs that should get upstreamed.

```
column_width ASCII/grapheme_column_width
                        time:   [23.413 ns 23.432 ns 23.451 ns]
column_width ASCII/grapheme_column_width_tbl
                        time:   [3.4066 ns 3.4092 ns 3.4121 ns]

column_width variation selector/grapheme_column_width
                        time:   [119.99 ns 120.13 ns 120.28 ns]
column_width variation selector/grapheme_column_width_tbl
                        time:   [21.185 ns 21.253 ns 21.346 ns]

column_width variation selector unicode 14/grapheme_column_width
                        time:   [119.44 ns 119.56 ns 119.69 ns]
column_width variation selector unicode 14/grapheme_column_width_tbl
                        time:   [21.214 ns 21.236 ns 21.264 ns]

column_width WidenedIn9/grapheme_column_width
                        time:   [99.652 ns 99.905 ns 100.18 ns]
column_width WidenedIn9/grapheme_column_width_tbl
                        time:   [21.394 ns 21.419 ns 21.446 ns]

column_width Unassigned/grapheme_column_width
                        time:   [82.767 ns 82.843 ns 82.926 ns]
column_width Unassigned/grapheme_column_width_tbl
                        time:   [24.230 ns 24.319 ns 24.428 ns]
```

Here's the benchmark summary after cleaning this diff up ready to commit; it shows ~70-80% improvement in these cases:

```
; cargo criterion -- column_width
column_width ASCII/grapheme_column_width
                        time:   [3.4237 ns 3.4347 ns 3.4463 ns]
                        change: [-85.401% -85.353% -85.302%] (p = 0.00 < 0.05)
                        Performance has improved.

column_width variation selector/grapheme_column_width
                        time:   [20.918 ns 20.935 ns 20.957 ns]
                        change: [-82.562% -82.384% -82.152%] (p = 0.00 < 0.05)
                        Performance has improved.

column_width variation selector unicode 14/grapheme_column_width
                        time:   [21.190 ns 21.210 ns 21.233 ns]
                        change: [-82.294% -82.261% -82.224%] (p = 0.00 < 0.05)
                        Performance has improved.

column_width WidenedIn9/grapheme_column_width
                        time:   [21.603 ns 21.630 ns 21.662 ns]
                        change: [-78.429% -78.375% -78.322%] (p = 0.00 < 0.05)
                        Performance has improved.

column_width Unassigned/grapheme_column_width
                        time:   [23.283 ns 23.355 ns 23.435 ns]
                        change: [-71.826% -71.734% -71.641%] (p = 0.00 < 0.05)
                        Performance has improved.
```