### PR TITLE
template.js: avoid #28 confusion in the future

### DIFF
--- a/templates/template.js
+++ b/templates/template.js
@@ -101,6 +101,14 @@ function {p}in_table(data, ucs) {{
 
 /* Return the width of character c, or a special negative value. */
 function {p}wcwidth(c) {{
+    if (typeof c === "string")
+        c = c.codePointAt();    /* Checking for if there's only one code point? Too much code. */
+    else if (typeof c !== "number")
+        throw new TypeError("Argument must be an integer or a string.");
+    
+    if (c < 0 || c > 0x10FFFF)
+        throw new RangeError("Argument must be inside Unicode code point range (0-U+10FFFF).");
+
     if ({p}in_table({p}ascii_table, c))
         return 1;
     if ({p}in_table({p}private_table, c))


### PR DESCRIPTION
This is supposed to be similar to the template.py part.

For what is worth, we could check the code-point length:
* `[...c].length == 1`, but why make a new object.
* Some stuff like `temp = c.codePointAt(); if (!(c.length == 1 || (temp > 0xFFFF && c.length == 2)) throw new Bucket()`. But why be so serious and make a whole new variable name.

Oh and this doesn't check for String and Number objects; you'd need the big toString dance to cover them. They do say it's considered harmful, so whatever.