### PR TITLE
widechar_width.rs: make no_std compatible

### DIFF
--- a/widechar_width.rs
+++ b/widechar_width.rs
@@ -1524,7 +1524,7 @@ const WIDENED_TABLE: &'static [R] = &[
 fn in_table(arr: &[R], c: u32) -> bool {
     arr.binary_search_by(|(start, end)| {
         if c >= *start && c <= *end {
-            std::cmp::Ordering::Equal
+            core::cmp::Ordering::Equal
         } else {
             start.cmp(&c)
         }


### PR DESCRIPTION
use core:: rather than std:: so that this can compile in a no_std library environment